### PR TITLE
Refactor UI abstraction and simplify status update handling

### DIFF
--- a/client/cmd/claude-status/main.go
+++ b/client/cmd/claude-status/main.go
@@ -7,6 +7,7 @@ import (
 
 	"claude-status/internal/app"
 	"claude-status/internal/config"
+	"claude-status/internal/tray"
 )
 
 var configPath = flag.String("config", "", "配置文件路径")
@@ -17,5 +18,6 @@ func main() {
 	if cp == "" {
 		cp = config.DefaultConfigPath()
 	}
-	app.Run(cp)
+	ui := tray.NewApp()
+	app.Run(cp, ui)
 }

--- a/client/internal/app/app.go
+++ b/client/internal/app/app.go
@@ -4,23 +4,24 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"claude-status/internal/config"
 	"claude-status/internal/installer"
 	"claude-status/internal/logger"
 	"claude-status/internal/monitor"
 	"claude-status/internal/ssh"
-	"claude-status/internal/tray"
 	"claude-status/internal/wsl"
 )
 
 // Run 运行应用
-func Run(configPath string) {
+func Run(configPath string, ui UI) {
 	// 初始化日志
 	if err := logger.Init(); err != nil {
 		// 日志初始化失败，静默继续
@@ -29,22 +30,19 @@ func Run(configPath string) {
 
 	logger.Info("Starting application...")
 
-	// 创建托盘应用
-	trayApp := tray.NewApp()
-
 	// 处理系统信号
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	// 启动托盘应用
-	trayApp.Run(func() {
+	ui.Run(func() {
 		// 托盘就绪后启动主逻辑
-		go appMain(trayApp, configPath, sigCh)
+		go appMain(ui, configPath, sigCh)
 	}, nil)
 }
 
 // appMain 应用主逻辑
-func appMain(trayApp *tray.App, configPath string, sigCh chan os.Signal) {
+func appMain(ui UI, configPath string, sigCh chan os.Signal) {
 	logger.Info("appMain started")
 
 	// 从 SSH config 加载主机列表
@@ -54,7 +52,7 @@ func appMain(trayApp *tray.App, configPath string, sigCh chan os.Signal) {
 	}
 	logger.Info("Loaded %d SSH hosts", len(servers))
 	if len(servers) > 0 {
-		trayApp.SetServers(servers)
+		ui.SetServers(servers)
 	}
 
 	// 检查配置文件是否存在
@@ -67,9 +65,9 @@ func appMain(trayApp *tray.App, configPath string, sigCh chan os.Signal) {
 		if len(servers) > 0 {
 			initialState = StateUnconfigured
 		} else {
-			trayApp.SetError("no_config", "配置文件不存在且无预设服务器")
+			ui.SetError("no_config", "配置文件不存在且无预设服务器")
 			select {
-			case <-trayApp.QuitChan():
+			case <-ui.QuitChan():
 				return
 			case <-sigCh:
 				return
@@ -84,9 +82,9 @@ func appMain(trayApp *tray.App, configPath string, sigCh chan os.Signal) {
 			if len(servers) > 0 {
 				initialState = StateUnconfigured
 			} else {
-				trayApp.SetError("no_config", "配置文件无效")
+				ui.SetError("no_config", "配置文件无效")
 				select {
-				case <-trayApp.QuitChan():
+				case <-ui.QuitChan():
 					return
 				case <-sigCh:
 					return
@@ -97,57 +95,56 @@ func appMain(trayApp *tray.App, configPath string, sigCh chan os.Signal) {
 			if cfg.Debug {
 				logger.SetDebug(true)
 			}
-			trayApp.SetStatusTimeout(cfg.StatusTimeout)
 			initialState = StateConnecting
 		}
 	}
 
 	// 启动状态机驱动的主循环
-	eventLoop(initialState, cfg, trayApp, configPath, sigCh)
+	eventLoop(initialState, cfg, ui, configPath, sigCh)
 }
 
 // eventLoop 状态机驱动的主循环
-func eventLoop(initialState State, cfg *config.Config, trayApp *tray.App, configPath string, sigCh chan os.Signal) {
+func eventLoop(initialState State, cfg *config.Config, ui UI, configPath string, sigCh chan os.Signal) {
 	sm := NewStateMachine(initialState, func(change StateChange) {
 		logger.Info("State: %s -> %s (event: %s)", change.From, change.To, change.Event)
-		applyTrayState(trayApp, change, cfg)
+		applyUIState(ui, change, cfg)
 	})
 
 	// 应用初始状态的 UI
-	applyTrayState(trayApp, StateChange{To: initialState, Valid: true}, cfg)
+	applyUIState(ui, StateChange{To: initialState, Valid: true}, cfg)
 
 	for sm.Current() != StateQuitting {
 		switch sm.Current() {
 		case StateUnconfigured:
-			cfg = handleUnconfigured(sm, cfg, trayApp, configPath, sigCh)
+			cfg = handleUnconfigured(sm, cfg, ui, configPath, sigCh)
 
 		case StateConnecting:
-			handleConnecting(sm, cfg, trayApp, configPath, sigCh)
+			handleConnecting(sm, cfg, ui, configPath, sigCh)
 
 		case StateInstalling:
-			handleInstalling(sm, cfg, trayApp)
+			handleInstalling(sm, cfg, ui)
 
 		case StateReinstalling:
-			handleReinstalling(sm, cfg, trayApp)
+			handleReinstalling(sm, cfg, ui)
 
 		case StateDisconnected, StateError:
-			cfg = handleWaitForUser(sm, cfg, trayApp, configPath, sigCh)
+			cfg = handleWaitForUser(sm, cfg, ui, configPath, sigCh)
 		}
 	}
 }
 
 // handleUnconfigured 处理未配置状态，等待用户选择服务器
-func handleUnconfigured(sm *StateMachine, cfg *config.Config, trayApp *tray.App, configPath string, sigCh chan os.Signal) *config.Config {
+func handleUnconfigured(sm *StateMachine, cfg *config.Config, ui UI, configPath string, sigCh chan os.Signal) *config.Config {
 	select {
-	case server := <-trayApp.ServerSelectChan():
-		newCfg := applyServerConfig(server, trayApp, configPath)
+	case server := <-ui.ServerSelectChan():
+		newCfg := applyServerConfig(server, configPath)
 		if newCfg != nil {
 			cfg = newCfg
 			sm.Transition(EventServerSelected)
 		} else {
-			trayApp.SetError("session_error", "保存配置失败")
+			ui.SetError("session_error", "保存配置失败")
 		}
-	case <-trayApp.QuitChan():
+	case <-ui.QuitChan():
 		sm.Transition(EventUserQuit)
 	case <-sigCh:
 		sm.Transition(EventUserQuit)
@@ -156,13 +153,13 @@ func handleUnconfigured(sm *StateMachine, cfg *config.Config, trayApp *tray.App,
 }
 
 // handleConnecting 处理连接状态
-func handleConnecting(sm *StateMachine, cfg *config.Config, trayApp *tray.App, configPath string, sigCh chan os.Signal) {
-	result := runConnection(sm, cfg, trayApp, sigCh)
+func handleConnecting(sm *StateMachine, cfg *config.Config, ui UI, configPath string, sigCh chan os.Signal) {
+	result := runConnection(sm, cfg, ui, sigCh)
 
 	// 连接结束后，根据结果触发事件（EventConnectSuccess 已在 runConnection 内部触发）
 	switch result.Event {
 	case EventConnectFailed, EventSessionError, EventSessionClosed:
-		trayApp.SetError(result.ErrorType, result.ErrorMsg)
+		ui.SetError(result.ErrorType, result.ErrorMsg)
 		sm.Transition(result.Event)
 	case EventVersionMismatch, EventNotConfigured:
 		sm.Transition(result.Event)
@@ -170,7 +167,7 @@ func handleConnecting(sm *StateMachine, cfg *config.Config, trayApp *tray.App, c
 		sm.Transition(result.Event)
 	case EventSwitchServer:
 		if result.NewServer != nil {
-			newCfg := applyServerConfig(*result.NewServer, trayApp, configPath)
+			newCfg := applyServerConfig(*result.NewServer, configPath)
 			if newCfg != nil {
 				*cfg = *newCfg
 			}
@@ -180,8 +177,8 @@ func handleConnecting(sm *StateMachine, cfg *config.Config, trayApp *tray.App, c
 }
 
 // handleInstalling 处理安装状态
-func handleInstalling(sm *StateMachine, cfg *config.Config, trayApp *tray.App) {
-	if doInstall(cfg, trayApp) {
+func handleInstalling(sm *StateMachine, cfg *config.Config, ui UI) {
+	if doInstall(cfg, ui) {
 		sm.Transition(EventInstallSuccess)
 	} else {
 		sm.Transition(EventInstallFailed)
@@ -189,8 +186,8 @@ func handleInstalling(sm *StateMachine, cfg *config.Config, trayApp *tray.App) {
 }
 
 // handleReinstalling 处理重新安装状态
-func handleReinstalling(sm *StateMachine, cfg *config.Config, trayApp *tray.App) {
-	if doReinstall(cfg, trayApp) {
+func handleReinstalling(sm *StateMachine, cfg *config.Config, ui UI) {
+	if doReinstall(cfg, ui) {
 		sm.Transition(EventInstallSuccess)
 	} else {
 		sm.Transition(EventInstallFailed)
@@ -198,15 +195,15 @@ func handleReinstalling(sm *StateMachine, cfg *config.Config, trayApp *tray.App)
 }
 
 // handleWaitForUser 处理断开/错误状态，等待用户操作
-func handleWaitForUser(sm *StateMachine, cfg *config.Config, trayApp *tray.App, configPath string, sigCh chan os.Signal) *config.Config {
+func handleWaitForUser(sm *StateMachine, cfg *config.Config, ui UI, configPath string, sigCh chan os.Signal) *config.Config {
 	select {
-	case server := <-trayApp.ServerSelectChan():
-		newCfg := applyServerConfig(server, trayApp, configPath)
+	case server := <-ui.ServerSelectChan():
+		newCfg := applyServerConfig(server, configPath)
 		if newCfg != nil {
 			cfg = newCfg
 		}
 		sm.Transition(EventServerSelected)
-	case <-trayApp.QuitChan():
+	case <-ui.QuitChan():
 		sm.Transition(EventUserQuit)
 	case <-sigCh:
 		sm.Transition(EventUserQuit)
@@ -215,14 +212,13 @@ func handleWaitForUser(sm *StateMachine, cfg *config.Config, trayApp *tray.App, 
 }
 
 // applyServerConfig 应用服务器配置并保存
-func applyServerConfig(server config.ServerConfig, trayApp *tray.App, configPath string) *config.Config {
+func applyServerConfig(server config.ServerConfig, configPath string) *config.Config {
 	cfg := config.NewFromServer(server)
 	cfg.ApplySSHConfig()
 
 	if cfg.StatusTimeout == 0 {
 		cfg.StatusTimeout = 300
 	}
-	trayApp.SetStatusTimeout(cfg.StatusTimeout)
 
 	if configPath != "" {
 		if err := config.Save(configPath, cfg); err != nil {
@@ -235,7 +231,7 @@ func applyServerConfig(server config.ServerConfig, trayApp *tray.App, configPath
 }
 
 // runConnection 运行一次连接，返回 ConnectionResult
-func runConnection(sm *StateMachine, cfg *config.Config, trayApp *tray.App, sigCh chan os.Signal) ConnectionResult {
+func runConnection(sm *StateMachine, cfg *config.Config, ui UI, sigCh chan os.Signal) ConnectionResult {
 	logger.Info("runConnection: mode=%s, display=%s", getMode(cfg), getDisplayName(cfg))
 
 	// 创建客户端（SSH 或 WSL）
@@ -287,11 +283,13 @@ func runConnection(sm *StateMachine, cfg *config.Config, trayApp *tray.App, sigC
 	logger.Info("Session started")
 	sm.Transition(EventConnectSuccess)
 
+	statusTimeout := int64(cfg.StatusTimeout)
+
 	// 主监控循环
 	for {
 		select {
 		case statuses := <-client.StatusChan():
-			trayApp.UpdateStatus(statuses)
+			processAndUpdateStatus(ui, statuses, statusTimeout)
 
 		case err := <-client.ErrorChan():
 			errMsg := err.Error()
@@ -312,14 +310,14 @@ func runConnection(sm *StateMachine, cfg *config.Config, trayApp *tray.App, sigC
 				ErrorMsg:  "连接已断开",
 			}
 
-		case <-trayApp.QuitChan():
+		case <-ui.QuitChan():
 			return ConnectionResult{Event: EventUserQuit}
 
-		case <-trayApp.DisconnectChan():
+		case <-ui.DisconnectChan():
 			logger.Info("用户主动断开连接")
 			return ConnectionResult{Event: EventUserDisconnect}
 
-		case server := <-trayApp.ServerSelectChan():
+		case server := <-ui.ServerSelectChan():
 			return ConnectionResult{
 				Event:     EventSwitchServer,
 				NewServer: &server,
@@ -331,8 +329,54 @@ func runConnection(sm *StateMachine, cfg *config.Config, trayApp *tray.App, sigC
 	}
 }
 
+// processAndUpdateStatus 过滤状态并更新 UI
+func processAndUpdateStatus(ui UI, statuses []monitor.ProjectStatus, statusTimeout int64) {
+	now := time.Now().Unix()
+
+	// 过滤掉 stopped 状态和超时的实例
+	filtered := make([]monitor.ProjectStatus, 0, len(statuses))
+	for _, s := range statuses {
+		if s.Status == "stopped" {
+			continue
+		}
+		if statusTimeout > 0 && now-s.UpdatedAt > statusTimeout {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	// 判断是否有项目在工作中
+	hasWorking := false
+	workingCount := 0
+	for _, s := range filtered {
+		if s.Status == "working" {
+			hasWorking = true
+			workingCount++
+		}
+	}
+
+	// 更新图标
+	if hasWorking {
+		ui.SetIcon("running")
+	} else {
+		ui.SetIcon("input-needed")
+	}
+
+	// 更新状态菜单项
+	if len(filtered) == 0 {
+		ui.SetStatusText("已连接 - 无活动项目")
+	} else if workingCount > 0 {
+		ui.SetStatusText(fmt.Sprintf("运行中 (%d 个项目)", workingCount))
+	} else {
+		ui.SetStatusText(fmt.Sprintf("等待输入 (%d 个项目)", len(filtered)))
+	}
+
+	// 更新悬浮窗口
+	ui.UpdatePopup(filtered)
+}
+
 // doInstall 执行首次安装，返回是否成功
-func doInstall(cfg *config.Config, trayApp *tray.App) bool {
+func doInstall(cfg *config.Config, ui UI) bool {
 	var inst monitor.Installer
 	if cfg.WSL.Enabled {
 		inst = wsl.NewInstaller(cfg)
@@ -342,7 +386,7 @@ func doInstall(cfg *config.Config, trayApp *tray.App) bool {
 
 	if err := inst.Connect(); err != nil {
 		logger.Error("安装器连接失败: %v", err)
-		trayApp.SetError("install_failed", "安装失败: "+err.Error())
+		ui.SetError("install_failed", "安装失败: "+err.Error())
 		return false
 	}
 	defer inst.Close()
@@ -350,14 +394,14 @@ func doInstall(cfg *config.Config, trayApp *tray.App) bool {
 	// 检查依赖
 	if ok, msg := inst.CheckDependencies(); !ok {
 		logger.Error("依赖检查失败: %s", msg)
-		trayApp.SetError("install_failed", msg)
+		ui.SetError("install_failed", msg)
 		return false
 	}
 
 	// 执行安装
 	if err := inst.Install(); err != nil {
 		logger.Error("安装失败: %v", err)
-		trayApp.SetError("install_failed", "安装失败: "+err.Error())
+		ui.SetError("install_failed", "安装失败: "+err.Error())
 		return false
 	}
 
@@ -366,7 +410,7 @@ func doInstall(cfg *config.Config, trayApp *tray.App) bool {
 }
 
 // doReinstall 执行重新安装（版本不匹配时），返回是否成功
-func doReinstall(cfg *config.Config, trayApp *tray.App) bool {
+func doReinstall(cfg *config.Config, ui UI) bool {
 	var inst monitor.Installer
 	if cfg.WSL.Enabled {
 		inst = wsl.NewInstaller(cfg)
@@ -376,7 +420,7 @@ func doReinstall(cfg *config.Config, trayApp *tray.App) bool {
 
 	if err := inst.Connect(); err != nil {
 		logger.Error("安装器连接失败: %v", err)
-		trayApp.SetError("install_failed", "更新失败: "+err.Error())
+		ui.SetError("install_failed", "更新失败: "+err.Error())
 		return false
 	}
 	defer inst.Close()
@@ -386,7 +430,7 @@ func doReinstall(cfg *config.Config, trayApp *tray.App) bool {
 	// 执行安装
 	if err := inst.Install(); err != nil {
 		logger.Error("更新失败: %v", err)
-		trayApp.SetError("install_failed", "更新失败: "+err.Error())
+		ui.SetError("install_failed", "更新失败: "+err.Error())
 		return false
 	}
 

--- a/client/internal/app/state_tray.go
+++ b/client/internal/app/state_tray.go
@@ -4,7 +4,6 @@ package app
 
 import (
 	"claude-status/internal/config"
-	"claude-status/internal/tray"
 )
 
 // ConnectionResult 连接结果（替代原来的 4 元组返回值）
@@ -12,11 +11,11 @@ type ConnectionResult struct {
 	Event     Event                // 触发的事件
 	NewServer *config.ServerConfig // EventSwitchServer 时非 nil
 	ErrorMsg  string               // 错误信息
-	ErrorType string               // 错误类型（用于 tray.SetError）
+	ErrorType string               // 错误类型
 }
 
-// applyTrayState 根据状态更新托盘 UI（图标、菜单、tooltip）
-func applyTrayState(trayApp *tray.App, change StateChange, cfg *config.Config) {
+// applyUIState 根据状态更新 UI（图标、菜单、tooltip）
+func applyUIState(ui UI, change StateChange, cfg *config.Config) {
 	var displayName string
 	if cfg != nil {
 		displayName = getDisplayName(cfg)
@@ -24,23 +23,22 @@ func applyTrayState(trayApp *tray.App, change StateChange, cfg *config.Config) {
 
 	switch change.To {
 	case StateUnconfigured:
-		trayApp.ShowServerSelection()
+		ui.ShowServerSelection()
 	case StateConnecting:
-		trayApp.SetConnecting(displayName)
-		trayApp.SetTooltip("正在连接 " + displayName + "...")
+		ui.SetConnecting(displayName)
+		ui.SetTooltip("正在连接 " + displayName + "...")
 	case StateInstalling:
-		trayApp.SetConnecting("正在安装服务端...")
-		trayApp.SetTooltip("正在安装服务端...")
+		ui.SetConnecting("正在安装服务端...")
+		ui.SetTooltip("正在安装服务端...")
 	case StateReinstalling:
-		trayApp.SetConnecting("版本不匹配，正在更新服务端...")
-		trayApp.SetTooltip("正在更新服务端...")
+		ui.SetConnecting("版本不匹配，正在更新服务端...")
+		ui.SetTooltip("正在更新服务端...")
 	case StateConnected:
-		trayApp.SetConnected(true, displayName)
-		// 已连接时不显示 tooltip，使用悬浮卡片
+		ui.SetConnected(displayName)
 	case StateDisconnected:
-		trayApp.SetDisconnected()
+		ui.SetDisconnected()
 	case StateError:
-		// 错误状态的具体信息由调用方在 Transition 前通过 trayApp.SetError 设置
+		// 错误状态的具体信息由调用方在 Transition 前通过 ui.SetError 设置
 	case StateQuitting:
 		// 退出状态无需更新 UI
 	}

--- a/client/internal/app/ui.go
+++ b/client/internal/app/ui.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"claude-status/internal/config"
+	"claude-status/internal/monitor"
+)
+
+// UI defines the interface between application logic and the user interface.
+// The app package drives business logic and calls UI methods to update display.
+// UI implementations handle platform-specific rendering.
+type UI interface {
+	// Run starts the UI event loop. onReady is called when the UI is initialized.
+	Run(onReady func(), onQuit func())
+
+	// SetServers sets the list of available servers in the connection menu.
+	SetServers(servers []config.ServerConfig)
+
+	// ShowServerSelection displays the server selection prompt.
+	ShowServerSelection()
+
+	// SetConnecting updates the UI to show a connecting state.
+	SetConnecting(msg string)
+
+	// SetConnected updates the UI to show a connected state.
+	SetConnected(msg string)
+
+	// SetDisconnected updates the UI to show a disconnected state.
+	SetDisconnected()
+
+	// SetError updates the UI to show an error state.
+	SetError(errType string, msg string)
+
+	// SetIcon sets the tray icon. Valid values: "disconnected", "input-needed", "running".
+	SetIcon(icon string)
+
+	// SetStatusText sets the status text in the context menu.
+	SetStatusText(text string)
+
+	// SetTooltip sets the tray icon tooltip text.
+	SetTooltip(text string)
+
+	// UpdatePopup updates the popup window with session statuses.
+	UpdatePopup(statuses []monitor.ProjectStatus)
+
+	// QuitChan returns a channel that is closed when the user requests quit.
+	QuitChan() <-chan struct{}
+
+	// DisconnectChan returns a channel that receives when the user requests disconnect.
+	DisconnectChan() <-chan struct{}
+
+	// ServerSelectChan returns a channel that receives the selected server config.
+	ServerSelectChan() <-chan config.ServerConfig
+}

--- a/client/internal/tray/tray.go
+++ b/client/internal/tray/tray.go
@@ -50,7 +50,6 @@ type App struct {
 	quitCh          chan struct{}
 	disconnectCh    chan struct{}
 	serverSelectCh  chan config.ServerConfig
-	updateCh        chan []monitor.ProjectStatus
 	currentIcon     string
 	connectedServer string
 
@@ -68,12 +67,6 @@ type App struct {
 	iconCache     map[string]*walk.Icon
 	iconCacheMu   sync.Mutex
 
-	// 状态超时（秒），0 或负数表示禁用
-	statusTimeout int64
-
-	// 记录每个会话的 working 开始时间（session_id -> Unix 时间戳）
-	workingStartTimes map[string]int64
-
 	// 悬浮检测
 	hoverMu       sync.Mutex
 	isHovering    bool
@@ -83,19 +76,17 @@ type App struct {
 // NewApp 创建托盘应用
 func NewApp() *App {
 	return &App{
-		statuses:          make([]monitor.ProjectStatus, 0),
-		servers:           make([]config.ServerConfig, 0),
-		quitCh:            make(chan struct{}),
-		disconnectCh:      make(chan struct{}, 1),
-		serverSelectCh:    make(chan config.ServerConfig, 1),
-		updateCh:          make(chan []monitor.ProjectStatus, 10),
-		currentIcon:       "",
-		serverMenuItems:   make([]*serverMenuItem, 0),
-		connectedServer:   "",
-		isDarkMode:        IsDarkMode(),
-		animFrame:         0,
-		workingStartTimes: make(map[string]int64),
-		iconCache:         make(map[string]*walk.Icon),
+		statuses:        make([]monitor.ProjectStatus, 0),
+		servers:         make([]config.ServerConfig, 0),
+		quitCh:          make(chan struct{}),
+		disconnectCh:    make(chan struct{}, 1),
+		serverSelectCh:  make(chan config.ServerConfig, 1),
+		currentIcon:     "",
+		serverMenuItems: make([]*serverMenuItem, 0),
+		connectedServer: "",
+		isDarkMode:      IsDarkMode(),
+		animFrame:       0,
+		iconCache:       make(map[string]*walk.Icon),
 	}
 }
 
@@ -166,7 +157,7 @@ func (t *App) onReady() {
 	logger.Info("Tray onReady called, isDarkMode=%v", t.isDarkMode)
 
 	// 设置图标
-	t.setIcon("disconnected")
+	t.SetIcon("disconnected")
 	t.notifyIcon.SetToolTip("Claude Code Status - 未连接")
 	t.notifyIcon.SetVisible(true)
 
@@ -193,9 +184,6 @@ func (t *App) onReady() {
 	})
 
 	logger.Info("Tray initialized")
-
-	// 监听状态更新
-	go t.watchUpdates()
 }
 
 // setupContextMenu 设置右键菜单
@@ -520,12 +508,12 @@ func (t *App) setIconData(data []byte) {
 	})
 }
 
-// setIcon 设置图标
-func (t *App) setIcon(name string) {
+// SetIcon 设置图标
+func (t *App) SetIcon(name string) {
 	if t.currentIcon == name {
 		return
 	}
-	logger.Info("setIcon: %s -> %s (isDark=%v)", t.currentIcon, name, t.isDarkMode)
+	logger.Info("SetIcon: %s -> %s (isDark=%v)", t.currentIcon, name, t.isDarkMode)
 	t.currentIcon = name
 	t.applyIcon(name)
 }
@@ -557,11 +545,6 @@ func (t *App) applyIcon(name string) {
 	case "running":
 		t.startAnimation()
 	}
-}
-
-// SetStatusTimeout 设置状态超时时间（秒），0 或负数表示禁用
-func (t *App) SetStatusTimeout(seconds int) {
-	t.statusTimeout = int64(seconds)
 }
 
 // SetServers 设置预设服务器列表
@@ -630,134 +613,6 @@ func (t *App) updateServerMenus() {
 	}
 }
 
-// watchUpdates 监听状态更新
-func (t *App) watchUpdates() {
-	for {
-		select {
-		case statuses := <-t.updateCh:
-			t.updateStatus(statuses)
-		case <-t.quitCh:
-			return
-		}
-	}
-}
-
-// UpdateStatus 更新状态（外部调用）
-func (t *App) UpdateStatus(statuses []monitor.ProjectStatus) {
-	select {
-	case t.updateCh <- statuses:
-	default:
-		select {
-		case <-t.updateCh:
-		default:
-		}
-		t.updateCh <- statuses
-	}
-}
-
-// updateStatus 内部更新状态
-func (t *App) updateStatus(statuses []monitor.ProjectStatus) {
-	now := time.Now().Unix()
-
-	// 过滤掉 stopped 状态和超时的实例
-	filtered := make([]monitor.ProjectStatus, 0, len(statuses))
-	activeProjects := make(map[string]bool)
-
-	for _, s := range statuses {
-		sessionKey := s.SessionId
-		if sessionKey == "" {
-			sessionKey = s.Project
-		}
-
-		if s.Status == "stopped" {
-			delete(t.workingStartTimes, sessionKey)
-			continue
-		}
-		if t.statusTimeout > 0 && now-s.UpdatedAt > t.statusTimeout {
-			delete(t.workingStartTimes, sessionKey)
-			continue
-		}
-
-		activeProjects[sessionKey] = true
-
-		if s.Status == "working" {
-			if _, exists := t.workingStartTimes[sessionKey]; !exists {
-				t.workingStartTimes[sessionKey] = s.UpdatedAt
-			}
-		} else {
-			delete(t.workingStartTimes, sessionKey)
-		}
-
-		filtered = append(filtered, s)
-	}
-
-	for sessionKey := range t.workingStartTimes {
-		if !activeProjects[sessionKey] {
-			delete(t.workingStartTimes, sessionKey)
-		}
-	}
-
-	t.statuses = filtered
-
-	// 判断是否有项目在工作中
-	hasWorking := false
-	for _, s := range filtered {
-		if s.Status == "working" {
-			hasWorking = true
-			break
-		}
-	}
-
-	// 更新图标
-	if hasWorking {
-		t.setIcon("running")
-	} else {
-		t.setIcon("input-needed")
-	}
-
-	// 更新状态菜单项
-	if len(t.statuses) == 0 {
-		t.mStatus.SetText("已连接 - 无活动项目")
-	} else {
-		workingCount := 0
-		for _, s := range t.statuses {
-			if s.Status == "working" {
-				workingCount++
-			}
-		}
-		if workingCount > 0 {
-			t.mStatus.SetText(fmt.Sprintf("运行中 (%d 个项目)", workingCount))
-		} else {
-			t.mStatus.SetText(fmt.Sprintf("等待输入 (%d 个项目)", len(t.statuses)))
-		}
-	}
-
-	// 更新悬浮窗口
-	if t.popupWindow != nil {
-		t.popupWindow.UpdateSessions(filtered)
-	}
-}
-
-// formatDuration 格式化时间间隔
-func formatDuration(d time.Duration) string {
-	totalSeconds := int(d.Seconds())
-
-	if totalSeconds < 60 {
-		return fmt.Sprintf("%ds", totalSeconds)
-	} else if totalSeconds < 3600 {
-		m := totalSeconds / 60
-		s := totalSeconds % 60
-		return fmt.Sprintf("%dm%ds", m, s)
-	} else if totalSeconds < 86400 {
-		h := totalSeconds / 3600
-		m := (totalSeconds % 3600) / 60
-		return fmt.Sprintf("%dh%dm", h, m)
-	}
-	days := totalSeconds / 86400
-	h := (totalSeconds % 86400) / 3600
-	return fmt.Sprintf("%dd%dh", days, h)
-}
-
 // QuitChan 返回退出 channel
 func (t *App) QuitChan() <-chan struct{} {
 	return t.quitCh
@@ -775,29 +630,23 @@ func (t *App) ServerSelectChan() <-chan config.ServerConfig {
 
 // SetConnecting 设置正在连接状态
 func (t *App) SetConnecting(msg string) {
-	t.setIcon("disconnected")
+	t.SetIcon("disconnected")
 	t.notifyIcon.SetToolTip("Claude Code Status - 正在连接...")
 	t.mStatus.SetText("正在连接 - " + msg)
 }
 
-// SetConnected 设置连接状态
-func (t *App) SetConnected(connected bool, msg string) {
-	if connected {
-		t.setIcon("input-needed")
-		t.notifyIcon.SetToolTip("") // 已连接时不显示 tooltip，使用悬浮卡片
-		t.mStatus.SetText("已连接 - " + msg)
-		t.connectedServer = msg
-		t.updateServerMenus()
-	} else {
-		t.setIcon("disconnected")
-		t.notifyIcon.SetToolTip("Claude Code Status - " + msg)
-		t.mStatus.SetText(msg)
-	}
+// SetConnected 设置已连接状态
+func (t *App) SetConnected(msg string) {
+	t.SetIcon("input-needed")
+	t.notifyIcon.SetToolTip("") // 已连接时不显示 tooltip，使用悬浮卡片
+	t.mStatus.SetText("已连接 - " + msg)
+	t.connectedServer = msg
+	t.updateServerMenus()
 }
 
 // SetDisconnected 设置用户主动断开状态
 func (t *App) SetDisconnected() {
-	t.setIcon("disconnected")
+	t.SetIcon("disconnected")
 	t.mStatus.SetText("已断开连接")
 	t.notifyIcon.SetToolTip("Claude Code Status - 已断开连接")
 	t.connectedServer = ""
@@ -806,7 +655,7 @@ func (t *App) SetDisconnected() {
 
 // SetError 设置错误状态
 func (t *App) SetError(errType string, msg string) {
-	t.setIcon("disconnected")
+	t.SetIcon("disconnected")
 
 	var statusMsg string
 	switch errType {
@@ -828,9 +677,14 @@ func (t *App) SetError(errType string, msg string) {
 
 // ShowServerSelection 显示服务器选择提示
 func (t *App) ShowServerSelection() {
-	t.setIcon("disconnected")
+	t.SetIcon("disconnected")
 	t.mStatus.SetText("请选择服务器")
 	t.notifyIcon.SetToolTip("Claude Code Status - 请选择服务器")
+}
+
+// SetStatusText 设置状态菜单项文本
+func (t *App) SetStatusText(text string) {
+	t.mStatus.SetText(text)
 }
 
 // SetTooltip 设置托盘图标的 tooltip 文本
@@ -839,5 +693,13 @@ func (t *App) SetTooltip(text string) {
 		t.notifyIcon.SetToolTip("")
 	} else {
 		t.notifyIcon.SetToolTip("Claude Code Status - " + text)
+	}
+}
+
+// UpdatePopup 更新悬浮窗口的会话状态
+func (t *App) UpdatePopup(statuses []monitor.ProjectStatus) {
+	t.statuses = statuses
+	if t.popupWindow != nil {
+		t.popupWindow.UpdateSessions(statuses)
 	}
 }


### PR DESCRIPTION
## Summary
This PR refactors the application to decouple business logic from the tray UI implementation by introducing a `UI` interface. It also simplifies status update handling by moving filtering and icon logic from the tray layer to the application layer.

## Key Changes

- **Introduced UI interface** (`client/internal/app/ui.go`): Defines a contract between application logic and UI implementations, allowing the app to be UI-agnostic. The tray implementation now satisfies this interface.

- **Removed status update channel and timeout tracking from tray**: 
  - Removed `updateCh` channel and `watchUpdates()` goroutine
  - Removed `statusTimeout` field and `SetStatusTimeout()` method
  - Removed `workingStartTimes` map and related timeout logic
  - Removed `UpdateStatus()` and internal `updateStatus()` methods

- **Moved status filtering logic to app layer**: Created `processAndUpdateStatus()` function in `app.go` that handles:
  - Filtering stopped and timed-out statuses
  - Determining working/input-needed icon state
  - Updating status text with project counts
  - Calling UI methods to update popup and icon

- **Simplified tray API**:
  - Changed `SetConnected(bool, string)` to `SetConnected(string)` - always represents connected state
  - Made `setIcon()` public as `SetIcon()`
  - Added `SetStatusText()` for direct status menu updates
  - Added `UpdatePopup()` for popup window updates

- **Updated app main logic** (`app.go`):
  - Changed `Run()` signature to accept `UI` interface instead of creating tray internally
  - Replaced all `trayApp` references with `ui` parameter
  - Removed `SetStatusTimeout()` calls
  - Status timeout is now passed directly to `processAndUpdateStatus()`

- **Updated main entry point** (`main.go`): Now creates tray app and passes it as UI implementation to `app.Run()`

## Implementation Details

The refactoring maintains the same user-facing behavior while improving separation of concerns. Status filtering that was previously done asynchronously in the tray is now done synchronously in the app layer when statuses arrive, eliminating the need for a separate update channel and timeout tracking state in the tray.

https://claude.ai/code/session_017urpvbNpaeMYvecBww97hv