### PR TITLE
Distinguish version check timeout from version mismatch errors

### DIFF
--- a/client/internal/app/app.go
+++ b/client/internal/app/app.go
@@ -260,6 +260,16 @@ func runConnection(sm *StateMachine, cfg *config.Config, ui UI, sigCh chan os.Si
 		logger.Error("Start failed: %v", err)
 		errMsg := err.Error()
 
+		// 检测是否是版本检查超时（不自动重装，交由用户决定）
+		if errors.Is(err, ssh.ErrVersionCheckTimeout) || errors.Is(err, wsl.ErrVersionCheckTimeout) {
+			logger.Info("版本检查超时，作为连接失败处理")
+			return ConnectionResult{
+				Event:     EventConnectFailed,
+				ErrorType: "version_check_timeout",
+				ErrorMsg:  "版本检查超时，请检查网络或稍后重试",
+			}
+		}
+
 		// 检测是否是版本不匹配
 		if errors.Is(err, ssh.ErrVersionMismatch) || errors.Is(err, wsl.ErrVersionMismatch) {
 			logger.Info("版本不匹配，触发重新安装...")

--- a/client/internal/ssh/client.go
+++ b/client/internal/ssh/client.go
@@ -20,6 +20,9 @@ import (
 // ErrVersionMismatch 版本不匹配错误
 var ErrVersionMismatch = errors.New("version mismatch")
 
+// ErrVersionCheckTimeout 版本检查超时（未在规定时间内收到服务端 version 消息）
+var ErrVersionCheckTimeout = errors.New("version check timeout")
+
 // Client SSH 客户端
 type Client struct {
 	config    *config.Config
@@ -141,9 +144,11 @@ func (c *Client) Start() error {
 			return ErrVersionMismatch
 		}
 	case <-time.After(5 * time.Second):
-		// 超时，假设是旧版本脚本（不输出版本信息）
-		logger.Info("版本检查超时，可能是旧版本脚本")
-		return ErrVersionMismatch
+		// 超时：未在 5 秒内收到服务端 version 消息。
+		// 常见原因：网络延迟、SSH 会话启动慢、或远端脚本卡住。
+		// 不做自动重装，交由上层处理并提示用户。
+		logger.Info("版本检查超时，未收到服务端版本消息")
+		return ErrVersionCheckTimeout
 	}
 
 	return nil

--- a/client/internal/tray/tray.go
+++ b/client/internal/tray/tray.go
@@ -667,6 +667,8 @@ func (t *App) SetError(errType string, msg string) {
 		statusMsg = "会话错误"
 	case "no_config":
 		statusMsg = "未配置"
+	case "version_check_timeout":
+		statusMsg = "版本检查超时"
 	default:
 		statusMsg = msg
 	}

--- a/client/internal/wsl/client.go
+++ b/client/internal/wsl/client.go
@@ -21,6 +21,9 @@ import (
 // ErrVersionMismatch 版本不匹配错误
 var ErrVersionMismatch = errors.New("version mismatch")
 
+// ErrVersionCheckTimeout 版本检查超时（未在规定时间内收到服务端 version 消息）
+var ErrVersionCheckTimeout = errors.New("version check timeout")
+
 // Client WSL 客户端
 type Client struct {
 	cfg       *config.Config
@@ -102,9 +105,11 @@ func (c *Client) Start() error {
 			return ErrVersionMismatch
 		}
 	case <-time.After(5 * time.Second):
-		// 超时，假设是旧版本脚本（不输出版本信息）
-		logger.Info("版本检查超时，可能是旧版本脚本")
-		return ErrVersionMismatch
+		// 超时：未在 5 秒内收到服务端 version 消息。
+		// 常见原因：WSL 进程启动慢、或远端脚本卡住。
+		// 不做自动重装，交由上层处理并提示用户。
+		logger.Info("版本检查超时，未收到服务端版本消息")
+		return ErrVersionCheckTimeout
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
This PR introduces a new error type `ErrVersionCheckTimeout` to distinguish between version check timeouts and actual version mismatches. Previously, both scenarios returned the same `ErrVersionMismatch` error, making it impossible to handle them differently. This change allows the application to treat timeouts as connection failures rather than triggering automatic reinstallation.

## Key Changes
- **New error type**: Added `ErrVersionCheckTimeout` in both SSH and WSL clients to represent timeout scenarios when the server version message is not received within 5 seconds
- **Updated timeout handling**: Changed the timeout case in both `ssh/client.go` and `wsl/client.go` to return the new error type instead of `ErrVersionMismatch`, with improved comments explaining common causes (network delays, slow process startup, or hung scripts)
- **Error differentiation in app layer**: Added explicit handling in `app/app.go` to detect version check timeouts and return them as connection failures with error type `"version_check_timeout"` rather than triggering automatic reinstallation
- **UI feedback**: Updated `tray/tray.go` to display "版本检查超时" (version check timeout) status message for this error type

## Implementation Details
- The timeout threshold remains 5 seconds across all clients
- Timeout errors are now treated as user-facing connection failures, allowing users to decide on retry/reinstall actions rather than automatic handling
- Log messages were clarified to indicate "未收到服务端版本消息" (version message not received) instead of assuming old script versions
- Comments explain that timeouts should be handled by upper layers with user notification

https://claude.ai/code/session_0172LWDsug392kdmRdhtEW3S