### PR TITLE
Add uninstall functionality for Claude Status service

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,22 @@ make all      # 编译
 使用客户端一键卸载（推荐）：
 
 ```powershell
+# 常规卸载（保留 settings.json 备份以防误操作）
 claude-status.exe --uninstall
+
+# 彻底清理，不留任何痕迹
+claude-status.exe --uninstall --purge
 ```
 
-该命令会连接配置中的服务器（SSH 或 WSL），执行：
+`--uninstall` 会连接配置中的服务器（SSH 或 WSL），执行：
 - 从 `~/.claude/settings.json` 移除所有 `status-hook.sh` 相关的 Hook
 - 删除 `~/.claude-status/` 目录（脚本 + 状态文件）
-- 先备份原 `settings.json` 为 `settings.json.backup.uninstall.*`
+- 将原 `settings.json` 备份为 `settings.json.backup.uninstall.<timestamp>`
+
+`--purge` 会在此基础上额外清理：
+- 删除所有 `~/.claude/settings.json.backup.*` 备份
+- 若 `settings.json` 此时已为空 `{}`（说明是我们安装时创建的）则删除
+- 若 `~/.claude` 目录因此变空则删除
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ make all      # 编译
 
 日志位置：程序同目录下 `claude-status.log`
 
+## 卸载
+
+### 客户端
+正常 Windows 卸载（MSI 或删除 exe）即可。
+
+### 服务端（脚本 + Hook）
+
+使用客户端一键卸载（推荐）：
+
+```powershell
+claude-status.exe --uninstall
+```
+
+该命令会连接配置中的服务器（SSH 或 WSL），执行：
+- 从 `~/.claude/settings.json` 移除所有 `status-hook.sh` 相关的 Hook
+- 删除 `~/.claude-status/` 目录（脚本 + 状态文件）
+- 先备份原 `settings.json` 为 `settings.json.backup.uninstall.*`
+
 ---
 
 <div align="center">

--- a/client/cmd/claude-status/main.go
+++ b/client/cmd/claude-status/main.go
@@ -4,13 +4,20 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
 
 	"claude-status/internal/app"
 	"claude-status/internal/config"
 	"claude-status/internal/tray"
 )
 
-var configPath = flag.String("config", "", "配置文件路径")
+var (
+	configPath   = flag.String("config", "", "配置文件路径")
+	uninstallCmd = flag.Bool("uninstall", false, "卸载服务器上的脚本和 Hook 配置后退出")
+)
 
 func main() {
 	flag.Parse()
@@ -18,6 +25,78 @@ func main() {
 	if cp == "" {
 		cp = config.DefaultConfigPath()
 	}
+
+	if *uninstallCmd {
+		runUninstallFlow(cp)
+		return
+	}
+
 	ui := tray.NewApp()
 	app.Run(cp, ui)
+}
+
+// runUninstallFlow 执行一次性卸载流程：
+//   - 尝试附加父进程控制台，便于在 PowerShell/CMD 中看到日志
+//   - 执行服务端卸载
+//   - 通过 MessageBox 给出结果反馈（双击运行时也能看到结果）
+func runUninstallFlow(configPath string) {
+	attachParentConsole()
+
+	err := app.RunUninstall(configPath)
+	if err != nil {
+		msg := "卸载失败: " + err.Error()
+		fmt.Fprintln(os.Stderr, msg)
+		showMessageBox("Claude Status 卸载", msg, true)
+		os.Exit(1)
+	}
+
+	msg := "服务端卸载完成\n\n已移除 ~/.claude/settings.json 中的 status-hook\n已删除 ~/.claude-status 目录"
+	fmt.Println("服务端卸载完成")
+	showMessageBox("Claude Status 卸载", msg, false)
+}
+
+// attachParentConsole 将进程附加到父进程的控制台，
+// 让 -H windowsgui 构建的二进制在从终端启动时也能输出文本。
+// 若没有父控制台（例如双击运行），静默返回，依赖 MessageBox 给用户反馈。
+func attachParentConsole() {
+	const attachParentProcess = ^uintptr(0) // -1
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	attachConsole := kernel32.NewProc("AttachConsole")
+
+	if r1, _, _ := attachConsole.Call(attachParentProcess); r1 == 0 {
+		return
+	}
+
+	// 通过 CONOUT$ 重新打开 stdout/stderr，指向刚附加上的控制台
+	if f, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0); err == nil {
+		os.Stdout = f
+		os.Stderr = f
+	}
+}
+
+// showMessageBox 弹出 Windows 系统 MessageBox
+func showMessageBox(title, message string, isError bool) {
+	titlePtr, err := syscall.UTF16PtrFromString(title)
+	if err != nil {
+		return
+	}
+	msgPtr, err := syscall.UTF16PtrFromString(message)
+	if err != nil {
+		return
+	}
+
+	// MB_OK | (MB_ICONERROR | MB_ICONINFORMATION)
+	var flags uintptr = 0x40 // MB_ICONINFORMATION
+	if isError {
+		flags = 0x10 // MB_ICONERROR
+	}
+
+	user32 := syscall.NewLazyDLL("user32.dll")
+	messageBox := user32.NewProc("MessageBoxW")
+	messageBox.Call(
+		0,
+		uintptr(unsafe.Pointer(msgPtr)),
+		uintptr(unsafe.Pointer(titlePtr)),
+		flags,
+	)
 }

--- a/client/cmd/claude-status/main.go
+++ b/client/cmd/claude-status/main.go
@@ -17,6 +17,7 @@ import (
 var (
 	configPath   = flag.String("config", "", "配置文件路径")
 	uninstallCmd = flag.Bool("uninstall", false, "卸载服务器上的脚本和 Hook 配置后退出")
+	purgeCmd     = flag.Bool("purge", false, "搭配 --uninstall 使用，额外删除 settings.json 备份以彻底清理")
 )
 
 func main() {
@@ -26,8 +27,8 @@ func main() {
 		cp = config.DefaultConfigPath()
 	}
 
-	if *uninstallCmd {
-		runUninstallFlow(cp)
+	if *uninstallCmd || *purgeCmd {
+		runUninstallFlow(cp, *purgeCmd)
 		return
 	}
 
@@ -39,10 +40,10 @@ func main() {
 //   - 尝试附加父进程控制台，便于在 PowerShell/CMD 中看到日志
 //   - 执行服务端卸载
 //   - 通过 MessageBox 给出结果反馈（双击运行时也能看到结果）
-func runUninstallFlow(configPath string) {
+func runUninstallFlow(configPath string, purge bool) {
 	attachParentConsole()
 
-	err := app.RunUninstall(configPath)
+	err := app.RunUninstall(configPath, purge)
 	if err != nil {
 		msg := "卸载失败: " + err.Error()
 		fmt.Fprintln(os.Stderr, msg)
@@ -50,7 +51,12 @@ func runUninstallFlow(configPath string) {
 		os.Exit(1)
 	}
 
-	msg := "服务端卸载完成\n\n已移除 ~/.claude/settings.json 中的 status-hook\n已删除 ~/.claude-status 目录"
+	var msg string
+	if purge {
+		msg = "服务端已彻底清理\n\n- 已移除 settings.json 中的 status-hook\n- 已删除 ~/.claude-status 目录\n- 已删除所有 settings.json.backup.* 备份\n- 若 settings.json 已为空也已删除"
+	} else {
+		msg = "服务端卸载完成\n\n- 已移除 settings.json 中的 status-hook\n- 已删除 ~/.claude-status 目录\n- 原 settings.json 已备份为 settings.json.backup.uninstall.*\n\n如需彻底清理备份，请使用 --uninstall --purge"
+	}
 	fmt.Println("服务端卸载完成")
 	showMessageBox("Claude Status 卸载", msg, false)
 }

--- a/client/internal/app/uninstall.go
+++ b/client/internal/app/uninstall.go
@@ -16,14 +16,19 @@ import (
 // 清理 ~/.claude/settings.json 中与 status-hook.sh 相关的 Hook，
 // 删除 ~/.claude-status/ 下的全部脚本与状态文件。
 //
+// purge=true 时额外：
+//   - 删除所有 ~/.claude/settings.json.backup.* 备份
+//   - 若 settings.json 退化为空 {} 则一并删除
+//   - 若 ~/.claude 目录因此变空也一并删除
+//
 // 该流程独立于托盘主循环，由 --uninstall 命令行参数触发后直接退出。
-func RunUninstall(configPath string) error {
+func RunUninstall(configPath string, purge bool) error {
 	// 初始化日志（失败不影响卸载流程）
 	if err := logger.Init(); err == nil {
 		defer logger.Close()
 	}
 
-	logger.Info("RunUninstall: configPath=%s", configPath)
+	logger.Info("RunUninstall: configPath=%s purge=%v", configPath, purge)
 
 	if !config.Exists(configPath) {
 		return fmt.Errorf("配置文件不存在: %s", configPath)
@@ -46,7 +51,7 @@ func RunUninstall(configPath string) error {
 	}
 	defer inst.Close()
 
-	if err := inst.Uninstall(); err != nil {
+	if err := inst.Uninstall(purge); err != nil {
 		return fmt.Errorf("卸载失败: %w", err)
 	}
 

--- a/client/internal/app/uninstall.go
+++ b/client/internal/app/uninstall.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package app
+
+import (
+	"fmt"
+
+	"claude-status/internal/config"
+	"claude-status/internal/installer"
+	"claude-status/internal/logger"
+	"claude-status/internal/monitor"
+	"claude-status/internal/wsl"
+)
+
+// RunUninstall 读取配置并在服务端执行卸载脚本，
+// 清理 ~/.claude/settings.json 中与 status-hook.sh 相关的 Hook，
+// 删除 ~/.claude-status/ 下的全部脚本与状态文件。
+//
+// 该流程独立于托盘主循环，由 --uninstall 命令行参数触发后直接退出。
+func RunUninstall(configPath string) error {
+	// 初始化日志（失败不影响卸载流程）
+	if err := logger.Init(); err == nil {
+		defer logger.Close()
+	}
+
+	logger.Info("RunUninstall: configPath=%s", configPath)
+
+	if !config.Exists(configPath) {
+		return fmt.Errorf("配置文件不存在: %s", configPath)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("加载配置失败: %w", err)
+	}
+
+	var inst monitor.Installer
+	if cfg.WSL.Enabled {
+		inst = wsl.NewInstaller(cfg)
+	} else {
+		inst = installer.NewInstaller(cfg)
+	}
+
+	if err := inst.Connect(); err != nil {
+		return fmt.Errorf("连接失败: %w", err)
+	}
+	defer inst.Close()
+
+	if err := inst.Uninstall(); err != nil {
+		return fmt.Errorf("卸载失败: %w", err)
+	}
+
+	logger.Info("服务端卸载完成")
+	return nil
+}

--- a/client/internal/installer/installer.go
+++ b/client/internal/installer/installer.go
@@ -178,8 +178,13 @@ func (i *Installer) Install() error {
 }
 
 // Uninstall 执行远程卸载：清理 Hook 配置并删除脚本/状态目录
-func (i *Installer) Uninstall() error {
-	logger.Info("开始远程卸载...")
+// purge=true 时额外删除 settings.json 的所有备份文件。
+func (i *Installer) Uninstall(purge bool) error {
+	if purge {
+		logger.Info("开始远程卸载（purge 模式）...")
+	} else {
+		logger.Info("开始远程卸载...")
+	}
 
 	session, err := i.client.NewSession()
 	if err != nil {
@@ -197,7 +202,12 @@ func (i *Installer) Uninstall() error {
 		io.WriteString(stdin, UninstallRemoteScript)
 	}()
 
-	output, err := session.CombinedOutput("bash -s")
+	cmd := "bash -s"
+	if purge {
+		cmd = "bash -s -- --purge"
+	}
+
+	output, err := session.CombinedOutput(cmd)
 	out := strings.TrimSpace(string(output))
 	if err != nil {
 		return fmt.Errorf("%w (output: %s)", err, out)

--- a/client/internal/installer/installer.go
+++ b/client/internal/installer/installer.go
@@ -26,6 +26,9 @@ var monitorScriptTemplate string
 //go:embed scripts/install-remote.sh
 var installRemoteScriptTemplate string
 
+//go:embed scripts/uninstall-remote.sh
+var uninstallRemoteScriptTemplate string
+
 // GetStatusHookScript 返回替换版本号后的脚本
 func GetStatusHookScript() string {
 	return stripCR(strings.ReplaceAll(statusHookScriptTemplate, "__VERSION__", version.Version))
@@ -41,17 +44,24 @@ func GetInstallRemoteScript() string {
 	return stripCR(strings.ReplaceAll(installRemoteScriptTemplate, "__VERSION__", version.Version))
 }
 
+// GetUninstallRemoteScript 返回替换版本号后的卸载脚本
+func GetUninstallRemoteScript() string {
+	return stripCR(strings.ReplaceAll(uninstallRemoteScriptTemplate, "__VERSION__", version.Version))
+}
+
 // 为保持兼容性，提供变量访问（延迟初始化）
 var (
-	StatusHookScript    = ""
-	MonitorScript       = ""
-	InstallRemoteScript = ""
+	StatusHookScript      = ""
+	MonitorScript         = ""
+	InstallRemoteScript   = ""
+	UninstallRemoteScript = ""
 )
 
 func init() {
 	StatusHookScript = GetStatusHookScript()
 	MonitorScript = GetMonitorScript()
 	InstallRemoteScript = GetInstallRemoteScript()
+	UninstallRemoteScript = GetUninstallRemoteScript()
 }
 
 // stripCR 去除 Windows CRLF 中的 \r，确保 shell 脚本在 Linux 上可正常执行
@@ -164,6 +174,39 @@ func (i *Installer) Install() error {
 	}
 
 	logger.Info("远程安装完成")
+	return nil
+}
+
+// Uninstall 执行远程卸载：清理 Hook 配置并删除脚本/状态目录
+func (i *Installer) Uninstall() error {
+	logger.Info("开始远程卸载...")
+
+	session, err := i.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("创建会话失败: %w", err)
+	}
+	defer session.Close()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("获取 stdin 失败: %w", err)
+	}
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, UninstallRemoteScript)
+	}()
+
+	output, err := session.CombinedOutput("bash -s")
+	out := strings.TrimSpace(string(output))
+	if err != nil {
+		return fmt.Errorf("%w (output: %s)", err, out)
+	}
+
+	if out != "" {
+		logger.Info("远程卸载输出:\n%s", out)
+	}
+	logger.Info("远程卸载完成")
 	return nil
 }
 

--- a/client/internal/installer/scripts/uninstall-remote.sh
+++ b/client/internal/installer/scripts/uninstall-remote.sh
@@ -6,13 +6,29 @@
 #   1. 停止正在运行的 monitor.sh 进程（避免 trap 再次写入 settings.json）
 #   2. 从 ~/.claude/settings.json 移除所有指向 status-hook.sh 的 Hook
 #   3. 删除 ~/.claude-status 目录（脚本 + 状态文件）
+#
+# 可选参数：
+#   --purge   额外清理 settings.json.backup.* 备份；若清理后
+#             settings.json 仅剩 {} 也一并删除，彻底不留痕迹
 
 set -u
 
 STATUS_DIR="$HOME/.claude-status"
-CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+CLAUDE_DIR="$HOME/.claude"
+CLAUDE_SETTINGS="$CLAUDE_DIR/settings.json"
 
-echo "[uninstall] 开始卸载 Claude Code Status..."
+PURGE=0
+for arg in "$@"; do
+    case "$arg" in
+        --purge) PURGE=1 ;;
+    esac
+done
+
+if [ "$PURGE" = "1" ]; then
+    echo "[uninstall] 开始卸载 Claude Code Status（purge 模式）..."
+else
+    echo "[uninstall] 开始卸载 Claude Code Status..."
+fi
 
 # 1. 停止正在运行的 monitor.sh（若存在）
 #    先关闭 monitor.sh 的 trap cleanup，避免它在退出时再次改写 settings.json
@@ -26,10 +42,12 @@ if command -v pkill &> /dev/null; then
 fi
 
 # 2. 清理 settings.json 中的 status-hook.sh 相关 Hook
+#    purge 模式下跳过备份（反正要删除），其他模式下留一份 uninstall 备份以防误操作
 if [ -f "$CLAUDE_SETTINGS" ]; then
     if command -v jq &> /dev/null; then
-        # 备份
-        cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.backup.uninstall.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
+        if [ "$PURGE" != "1" ]; then
+            cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.backup.uninstall.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
+        fi
 
         if jq '
             def remove_status_hooks:
@@ -37,6 +55,8 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
                 elif (. | length) == 0 then .
                 else [.[] | select(.hooks[0].command | contains("status-hook.sh") | not)]
                 end;
+
+            def is_empty: . == null or . == [];
 
             if .hooks then
                 .hooks.UserPromptSubmit  = (.hooks.UserPromptSubmit  | remove_status_hooks) |
@@ -46,12 +66,12 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
                 .hooks.SessionStart      = (.hooks.SessionStart      | remove_status_hooks) |
                 .hooks.SessionEnd        = (.hooks.SessionEnd        | remove_status_hooks) |
 
-                (if .hooks.UserPromptSubmit  == [] then del(.hooks.UserPromptSubmit)  else . end) |
-                (if .hooks.PostToolUse       == [] then del(.hooks.PostToolUse)       else . end) |
-                (if .hooks.Stop              == [] then del(.hooks.Stop)              else . end) |
-                (if .hooks.PermissionRequest == [] then del(.hooks.PermissionRequest) else . end) |
-                (if .hooks.SessionStart      == [] then del(.hooks.SessionStart)      else . end) |
-                (if .hooks.SessionEnd        == [] then del(.hooks.SessionEnd)        else . end) |
+                (if .hooks.UserPromptSubmit  | is_empty then del(.hooks.UserPromptSubmit)  else . end) |
+                (if .hooks.PostToolUse       | is_empty then del(.hooks.PostToolUse)       else . end) |
+                (if .hooks.Stop              | is_empty then del(.hooks.Stop)              else . end) |
+                (if .hooks.PermissionRequest | is_empty then del(.hooks.PermissionRequest) else . end) |
+                (if .hooks.SessionStart      | is_empty then del(.hooks.SessionStart)      else . end) |
+                (if .hooks.SessionEnd        | is_empty then del(.hooks.SessionEnd)        else . end) |
                 (if .hooks == {} then del(.hooks) else . end)
             else . end
         ' "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" 2>/dev/null; then
@@ -75,6 +95,33 @@ if [ -d "$STATUS_DIR" ]; then
     echo "[uninstall] 已删除目录: $STATUS_DIR"
 else
     echo "[uninstall] $STATUS_DIR 不存在，跳过目录清理"
+fi
+
+# 4. purge 模式：删除 install/uninstall 产生的所有 settings.json 备份；
+#    若 settings.json 本身已退化为空对象 {}，也一并删除（说明是我们当初
+#    为了写入 hook 而创建的空文件，用户并没有自己的 Claude Code 配置）。
+if [ "$PURGE" = "1" ]; then
+    # 用 nullglob 避免未匹配时展开为字面字符串
+    shopt -s nullglob 2>/dev/null || true
+    backups=("$CLAUDE_DIR"/settings.json.backup.*)
+    if [ ${#backups[@]} -gt 0 ]; then
+        rm -f "${backups[@]}"
+        echo "[uninstall] 已删除 ${#backups[@]} 个 settings.json 备份"
+    fi
+    shopt -u nullglob 2>/dev/null || true
+
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq &> /dev/null; then
+        if jq -e 'type == "object" and length == 0' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+            rm -f "$CLAUDE_SETTINGS"
+            echo "[uninstall] settings.json 已为空，已删除"
+        fi
+    fi
+
+    # 若 ~/.claude 目录此刻已完全为空（用户无任何其他 Claude Code 配置），
+    # 顺手清理掉，真正不留痕迹
+    if [ -d "$CLAUDE_DIR" ] && [ -z "$(ls -A "$CLAUDE_DIR" 2>/dev/null)" ]; then
+        rmdir "$CLAUDE_DIR" 2>/dev/null && echo "[uninstall] $CLAUDE_DIR 已为空，已删除"
+    fi
 fi
 
 echo "[uninstall] 卸载完成"

--- a/client/internal/installer/scripts/uninstall-remote.sh
+++ b/client/internal/installer/scripts/uninstall-remote.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# 远程卸载脚本 - 清理 Claude Code Hooks 和 status-hook 相关文件
+# 由客户端通过 SSH/WSL 执行
+#
+# 执行步骤：
+#   1. 停止正在运行的 monitor.sh 进程（避免 trap 再次写入 settings.json）
+#   2. 从 ~/.claude/settings.json 移除所有指向 status-hook.sh 的 Hook
+#   3. 删除 ~/.claude-status 目录（脚本 + 状态文件）
+
+set -u
+
+STATUS_DIR="$HOME/.claude-status"
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+
+echo "[uninstall] 开始卸载 Claude Code Status..."
+
+# 1. 停止正在运行的 monitor.sh（若存在）
+#    先关闭 monitor.sh 的 trap cleanup，避免它在退出时再次改写 settings.json
+if command -v pkill &> /dev/null; then
+    if pgrep -f "$STATUS_DIR/monitor.sh" > /dev/null 2>&1; then
+        echo "[uninstall] 停止正在运行的 monitor.sh..."
+        pkill -f "$STATUS_DIR/monitor.sh" 2>/dev/null || true
+        # 给进程一点时间退出（它自身的 cleanup 也会尝试清理 hook，幂等）
+        sleep 1
+    fi
+fi
+
+# 2. 清理 settings.json 中的 status-hook.sh 相关 Hook
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if command -v jq &> /dev/null; then
+        # 备份
+        cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.backup.uninstall.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
+
+        if jq '
+            def remove_status_hooks:
+                if . == null then null
+                elif (. | length) == 0 then .
+                else [.[] | select(.hooks[0].command | contains("status-hook.sh") | not)]
+                end;
+
+            if .hooks then
+                .hooks.UserPromptSubmit  = (.hooks.UserPromptSubmit  | remove_status_hooks) |
+                .hooks.PostToolUse       = (.hooks.PostToolUse       | remove_status_hooks) |
+                .hooks.Stop              = (.hooks.Stop              | remove_status_hooks) |
+                .hooks.PermissionRequest = (.hooks.PermissionRequest | remove_status_hooks) |
+                .hooks.SessionStart      = (.hooks.SessionStart      | remove_status_hooks) |
+                .hooks.SessionEnd        = (.hooks.SessionEnd        | remove_status_hooks) |
+
+                (if .hooks.UserPromptSubmit  == [] then del(.hooks.UserPromptSubmit)  else . end) |
+                (if .hooks.PostToolUse       == [] then del(.hooks.PostToolUse)       else . end) |
+                (if .hooks.Stop              == [] then del(.hooks.Stop)              else . end) |
+                (if .hooks.PermissionRequest == [] then del(.hooks.PermissionRequest) else . end) |
+                (if .hooks.SessionStart      == [] then del(.hooks.SessionStart)      else . end) |
+                (if .hooks.SessionEnd        == [] then del(.hooks.SessionEnd)        else . end) |
+                (if .hooks == {} then del(.hooks) else . end)
+            else . end
+        ' "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" 2>/dev/null; then
+            mv -f "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+            echo "[uninstall] 已从 settings.json 移除 Hook 配置"
+        else
+            rm -f "$CLAUDE_SETTINGS.tmp" 2>/dev/null || true
+            echo "[uninstall] 警告: 更新 settings.json 失败，请手动检查" >&2
+        fi
+    else
+        echo "[uninstall] 警告: 未安装 jq，跳过 settings.json 清理" >&2
+        echo "[uninstall] 请手动编辑 $CLAUDE_SETTINGS 移除 command 包含 status-hook.sh 的项" >&2
+    fi
+else
+    echo "[uninstall] $CLAUDE_SETTINGS 不存在，跳过 Hook 清理"
+fi
+
+# 3. 删除脚本和状态文件目录
+if [ -d "$STATUS_DIR" ]; then
+    rm -rf "$STATUS_DIR"
+    echo "[uninstall] 已删除目录: $STATUS_DIR"
+else
+    echo "[uninstall] $STATUS_DIR 不存在，跳过目录清理"
+fi
+
+echo "[uninstall] 卸载完成"

--- a/client/internal/monitor/types.go
+++ b/client/internal/monitor/types.go
@@ -40,4 +40,5 @@ type Installer interface {
 	Close()
 	CheckDependencies() (bool, string)
 	Install() error
+	Uninstall() error
 }

--- a/client/internal/monitor/types.go
+++ b/client/internal/monitor/types.go
@@ -40,5 +40,7 @@ type Installer interface {
 	Close()
 	CheckDependencies() (bool, string)
 	Install() error
-	Uninstall() error
+	// Uninstall 执行服务端卸载。purge=true 时额外清理 settings.json 备份
+	// 以及我们安装时创建的空 settings.json（彻底不留痕迹）。
+	Uninstall(purge bool) error
 }

--- a/client/internal/wsl/installer.go
+++ b/client/internal/wsl/installer.go
@@ -79,6 +79,24 @@ func (i *Installer) Install() error {
 	return nil
 }
 
+// Uninstall 执行 WSL 端卸载
+func (i *Installer) Uninstall() error {
+	logger.Info("开始 WSL 卸载...")
+
+	cmd := fmt.Sprintf("bash -s << 'EOFSCRIPT'\n%s\nEOFSCRIPT", installer.UninstallRemoteScript)
+	output, err := i.runCommand(cmd)
+	out := strings.TrimSpace(output)
+	if err != nil {
+		return fmt.Errorf("%w (output: %s)", err, out)
+	}
+
+	if out != "" {
+		logger.Info("WSL 卸载输出:\n%s", out)
+	}
+	logger.Info("WSL 卸载完成")
+	return nil
+}
+
 // runCommand 执行 WSL 命令
 func (i *Installer) runCommand(command string) (string, error) {
 	args := []string{}

--- a/client/internal/wsl/installer.go
+++ b/client/internal/wsl/installer.go
@@ -80,10 +80,20 @@ func (i *Installer) Install() error {
 }
 
 // Uninstall 执行 WSL 端卸载
-func (i *Installer) Uninstall() error {
-	logger.Info("开始 WSL 卸载...")
+// purge=true 时额外删除 settings.json 的所有备份文件。
+func (i *Installer) Uninstall(purge bool) error {
+	if purge {
+		logger.Info("开始 WSL 卸载（purge 模式）...")
+	} else {
+		logger.Info("开始 WSL 卸载...")
+	}
 
-	cmd := fmt.Sprintf("bash -s << 'EOFSCRIPT'\n%s\nEOFSCRIPT", installer.UninstallRemoteScript)
+	bashArgs := "bash -s"
+	if purge {
+		bashArgs = "bash -s -- --purge"
+	}
+
+	cmd := fmt.Sprintf("%s << 'EOFSCRIPT'\n%s\nEOFSCRIPT", bashArgs, installer.UninstallRemoteScript)
 	output, err := i.runCommand(cmd)
 	out := strings.TrimSpace(output)
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR adds a complete uninstall flow for the Claude Status service, allowing users to cleanly remove server-side scripts and Hook configurations via command-line flags.

## Key Changes

- **New uninstall script** (`uninstall-remote.sh`): Bash script executed on the remote server that:
  - Stops running `monitor.sh` processes
  - Removes all `status-hook.sh` references from `~/.claude/settings.json`
  - Deletes the `~/.claude-status/` directory
  - Optionally (with `--purge`) removes backup files and empty configuration directories

- **CLI uninstall commands**: Added `--uninstall` and `--purge` flags to the main executable:
  - `--uninstall`: Standard uninstall with backup preservation
  - `--purge`: Aggressive cleanup that removes all traces including backups

- **Windows console integration**: Added `attachParentConsole()` to allow GUI-built binary to output to parent console when launched from terminal, with fallback to `MessageBox` for user feedback

- **Uninstall orchestration** (`RunUninstall`): New function in `internal/app/uninstall.go` that:
  - Loads configuration
  - Delegates to appropriate installer (SSH or WSL)
  - Handles errors and displays results via MessageBox

- **Installer interface updates**: Extended both SSH and WSL installers with `Uninstall(purge bool)` method that executes the remote uninstall script with appropriate parameters

- **Documentation**: Updated README with uninstall instructions for both client and server components

## Implementation Details

- The uninstall script uses `jq` for safe JSON manipulation of `settings.json`, with graceful fallback if unavailable
- Process termination uses `pkill` to stop monitor processes before modifying configuration
- Backup creation is skipped in purge mode but preserved in standard mode with timestamp
- Empty configuration directories are cleaned up only in purge mode to avoid leaving orphaned directories
- The flow is independent of the main tray application and exits immediately after completion

https://claude.ai/code/session_019acnA51Aom1cMsCZMgQ1cE